### PR TITLE
Add mapping between classifiers and versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+
+recursive-include docs *
+recursive-include Products *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.rst
 
 recursive-include docs *
 recursive-include Products *
+
+global-exclude *.pyc

--- a/Products/PloneSoftwareCenter/browser/configure.zcml
+++ b/Products/PloneSoftwareCenter/browser/configure.zcml
@@ -172,4 +172,12 @@
         file="fancyzoom.js"
         />
 
+    <!-- pypi view -->
+    <page
+        class=".pypi_view.PackageIndexView"
+        for="Products.PloneSoftwareCenter.interfaces.ISoftwareCenterContent"
+        name="pypi_view"
+        permission="zope2.View"
+        />
+  
 </configure>

--- a/Products/PloneSoftwareCenter/browser/pypi.py
+++ b/Products/PloneSoftwareCenter/browser/pypi.py
@@ -3,6 +3,7 @@ $Id: PyPI.py 18612 2006-01-28 14:46:00Z dreamcatcher $
 """
 import re
 import hashlib
+from decimal import Decimal, InvalidOperation
 
 from AccessControl import getSecurityManager
 from AccessControl import Unauthorized
@@ -347,7 +348,27 @@ class PyPIView(BrowserView):
                             (version, name))
 
         release = releases._getOb(version)
+        self._map_classifiers_to_compatibility(project, release)
+
         return project, release
+
+    def _map_classifiers_to_compatibility(self, project, release):
+        classifiers_id = release.getClassifiers()
+        versions = []
+        for cid in classifiers_id:
+            try:
+                Decimal(cid)
+            except InvalidOperation:
+                continue
+            versions.append('Plone %s' % cid)
+
+        vocab = release.getCompatibilityVocab()
+        compats = []
+        for version in versions:
+            if version in vocab:
+                compats.append(version)
+        if compats:
+            release.setCompatibility(compats)
 
     def _get_classifiers(self):
         """returns current classifiers"""

--- a/Products/PloneSoftwareCenter/browser/pypi.py
+++ b/Products/PloneSoftwareCenter/browser/pypi.py
@@ -482,9 +482,9 @@ class PyPIView(BrowserView):
         # XXX optimize for memory
         content = content.read()
 
-        # nothing over 5M please
+        # nothing over 100M please
         size = len(content)
-        if size > 5*1024*1024:
+        if size > 100*1024*1024:
             err = 'Invalid file size: %s' % size
             return self.fail(err)
 

--- a/Products/PloneSoftwareCenter/browser/pypi.py
+++ b/Products/PloneSoftwareCenter/browser/pypi.py
@@ -353,14 +353,18 @@ class PyPIView(BrowserView):
         return project, release
 
     def _map_classifiers_to_compatibility(self, project, release):
-        classifiers_id = release.getClassifiers()
         versions = []
-        for cid in classifiers_id:
+        CLASSIFIER_BASE = 'Framework :: Plone :: '
+        supported_versions = [classifier[len(CLASSIFIER_BASE):] for classifier in \
+                       self.request.form.get('classifiers', [])\
+                       if classifier.startswith(CLASSIFIER_BASE)]
+
+        for supported_version in supported_versions:
             try:
-                Decimal(cid)
+                Decimal(supported_version)
             except InvalidOperation:
                 continue
-            versions.append('Plone %s' % cid)
+            versions.append('Plone %s' % supported_version)
 
         vocab = release.getCompatibilityVocab()
         compats = []

--- a/Products/PloneSoftwareCenter/browser/pypi.py
+++ b/Products/PloneSoftwareCenter/browser/pypi.py
@@ -25,7 +25,7 @@ from plone.i18n.normalizer.interfaces import IFileNameNormalizer
 
 from zope.annotation.interfaces import IAnnotations
 from zope.component import queryUtility
-from zope.event import notify 
+from zope.event import notify
 
 safe_filenames = re.compile(r'.+?\.(exe|tar\.gz|bz2|egg|rpm|deb|zip|tgz)$', re.I)
 
@@ -37,7 +37,7 @@ PROJECT_MAP = {
     'contactAddress': 'author_email',
     'homepage': 'home_page',
     }
-        
+
 RELEASE_MAP = {
     'license': 'license',
     # 'maturity': 'classifiers',
@@ -82,7 +82,7 @@ class PyPIView(BrowserView):
     def _maybe_release(self, project, release):
         """Publishing the release, only of the project is published."""
         if not self._is_published(project):
-            return 
+            return
         wf = self._get_portal_workflow()
         if wf is None:
             return
@@ -95,13 +95,13 @@ class PyPIView(BrowserView):
                     wf.doActionFor(release, 'release-alpha')
                 elif bool(re.compile("([0-9]+(-)?b([0-9]*))").search(self.data['version'])):
                     wf.doActionFor(release, 'release-beta')
-                elif bool(re.compile("([0-9]+(-)?rc([0-9]*))").search(self.data['version'])):                
+                elif bool(re.compile("([0-9]+(-)?rc([0-9]*))").search(self.data['version'])):
                     wf.doActionFor(release, 'release-candidate')
                 else:
                     wf.doActionFor(release, 'release-final')
             except WorkflowException:
                 pass
-    
+
     def _validate_metadata(self, data):
         """ Validate the contents of the metadata.
         """
@@ -146,7 +146,7 @@ class PyPIView(BrowserView):
 
         if data.has_key('classifiers'):
             data['classifiers'] = filter(filter_, data['classifiers'])
-    
+
     def _is_published(self, project):
         """returns true if not publised"""
         wf = self._get_portal_workflow()
@@ -169,7 +169,7 @@ class PyPIView(BrowserView):
             return self.fail(str(e), 401)
 
         # Now, edit info
-        self._edit_project(project, distutils_name=name, data=data, 
+        self._edit_project(project, distutils_name=name, data=data,
                            msg=msg)
 
         # Submit project if not submitted yet.
@@ -183,14 +183,14 @@ class PyPIView(BrowserView):
             if v in ('author_email',) and not value.startswith('mailto:'):
                 value = 'mailto:%s' % value
             release_data[k] = value
-        
+
         if not user.allowed(release.update):
             return self.fail('Unauthorized', 401)
 
         msg.append('Updated Release: %s' % version)
         release.update(**release_data)
 
-  
+
         # Now, check if there's a 'download_url', then create a file
         # link
         url = data.get('download_url')
@@ -222,19 +222,19 @@ class PyPIView(BrowserView):
 
             # notify we did add a file
             notify(ObjectEditedEvent(rl))
- 
+
         # Make a release if not released yet.
         self._maybe_release(project, release)
-  
+
         return '\n'.join(msg)
-    
+
     def _edit_project(self, project, distutils_name=None,
                       data=None, msg=None):
         """edit project infos"""
         user = getSecurityManager().getUser()
         if not user.allowed(project.update):
             return self.fail('Unauthorized', 401)
-        
+
         if data is None:
             data = self.data
         project_data = {}
@@ -264,7 +264,7 @@ class PyPIView(BrowserView):
             elif not (distutils_name == project.getDistutilsMainId()):
                 secondary_ids = project.getDistutilsSecondaryIds()
                 if distutils_name not in secondary_ids:
-                    secondary_ids = secondary_ids + (distutils_name,) 
+                    secondary_ids = secondary_ids + (distutils_name,)
                     project.setDistutilsSecondaryIds(secondary_ids)
             else:
                 priority='m'
@@ -272,7 +272,7 @@ class PyPIView(BrowserView):
             # setting the title in case it is empty
             if project.Title() == '':
                 project_data['title'] = distutils_name
-        
+
         if priority == 'm':
             project.update(**project_data)
 
@@ -299,7 +299,7 @@ class PyPIView(BrowserView):
                 if project.getDistutilsMainId() == '':
                     project.setDistutilsMainId(normalized_name)
                 else:
-                    # main id is taken, let's add it 
+                    # main id is taken, let's add it
                     # as a secondary id
                     secondids = project.getDistutilsSecondaryIds()
                     secondids = secondids + (normalized_name,)
@@ -316,7 +316,7 @@ class PyPIView(BrowserView):
         else:
             project_id = existing_projects[0]
             project = sc[project_id]
-         
+
         self._edit_project(project, msg=msg, distutils_name=name)
         versions = project.getVersionsVocab()
         releases = project.getReleaseFolder()
@@ -328,7 +328,7 @@ class PyPIView(BrowserView):
                 i += 1
                 cid = '%s-%d' (root_id, i)
 
-            releases = project.injectFolder('PSCReleaseFolder', 
+            releases = project.injectFolder('PSCReleaseFolder',
                                             id=cid)
 
         is_secondary = name != project.distutilsMainId
@@ -416,7 +416,7 @@ class PyPIView(BrowserView):
         """
         if getSecurityManager().getUser() in (nobody,):
             return self.fail('Unauthorized', 401)
-        
+
         if data is None:
             data = self.request.form
 
@@ -454,7 +454,7 @@ class PyPIView(BrowserView):
                                                  name, version)
         except Unauthorized, e:
             return self.fail(str(e), 401)
-            
+
         # Submit project if not submitted yet.
         self._maybe_submit(project)
 
@@ -523,7 +523,7 @@ class PyPIView(BrowserView):
         self._setPlatform(rf, filename)
         # notify
         notify(ObjectEditedEvent(rf))
-        
+
         # Make a release if not released yet.
         self._maybe_release(project, release)
 
@@ -551,8 +551,8 @@ class PyPIView(BrowserView):
         # Remove Products, as applicable
         if text.startswith('Products.'):
             text = text[9:]
-        
+
         # Convert to lowercase
         text = text.lower()
-        
+
         return queryUtility(IFileNameNormalizer).normalize(text)

--- a/Products/PloneSoftwareCenter/browser/pypi_view.pt
+++ b/Products/PloneSoftwareCenter/browser/pypi_view.pt
@@ -1,0 +1,9 @@
+<div metal:use-macro="here/main_template/macros/master">
+
+    <div metal:fill-slot="main">
+
+        <h1>PyPI View</h1>
+
+    </div>
+
+</div>

--- a/Products/PloneSoftwareCenter/browser/pypi_view.py
+++ b/Products/PloneSoftwareCenter/browser/pypi_view.py
@@ -1,0 +1,13 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.publisher.browser import BrowserPage
+
+
+class PackageIndexView(BrowserPage):
+    """
+    Display Plone releases from PyPI
+    """
+
+    template = ViewPageTemplateFile('pypi_view.pt')
+
+    def __call__(self):
+        return self.template()

--- a/Products/PloneSoftwareCenter/profiles/default/types/PloneSoftwareCenter.xml
+++ b/Products/PloneSoftwareCenter/profiles/default/types/PloneSoftwareCenter.xml
@@ -22,6 +22,7 @@
   <element value="plonesoftwarecenter_view"/>
   <element value="plonesoftwarecenter_ploneorg"/>
   <element value="psc_view_ploneorg"/>
+  <element value="pypi_view"/>
  </property>
  <property name="default_view_fallback">False</property>
  <alias from="(Default)" to="(dynamic view)"/>

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Update classifiers [toutpt]
 - Update TROVE.txt [toutpt]
 - Update default available versions of Plone [toutpt]
+- Add mapping between classifiers and Plone release version when release using pypi api [toutpt]
 
 1.6.3 (2011-06-19)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.6.4 (unreleased)
+1.6.4 (2012-09-27)
 ------------------
 - Default content and output format added to the StringField installation_instructions in content/root.py [andreasma]
 - Change to psc_project_view.pt: more than one license will be displayed, if there is not only one for a release [andreasma]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.6.5 (unreleased)
+------------------
+
+- Nothing changed yet.
+
+
 1.6.4 (2012-09-27)
 ------------------
 - Default content and output format added to the StringField installation_instructions in content/root.py [andreasma]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.6.3'
+version = '1.6.4'
 
 
 def read(*rnames):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.6.4'
+version = '1.6.5.dev0'
 
 
 def read(*rnames):


### PR DESCRIPTION
It is really boring that we specify in setup.py the version of Plone supported using classifiers and need to do it by hand in the plonesoftware center.

Here I have added a mapping to support this directly. I would be glade that someone review this change and apply it. If no changes and no discussion happens I will merge it myself in one week.

Any feedback welcomed
